### PR TITLE
logging: Logger() usage causes 'logger cannot be pickled' in multithreaded env

### DIFF
--- a/ms_identity_web/__init__.py
+++ b/ms_identity_web/__init__.py
@@ -1,7 +1,7 @@
 from msal import ConfidentialClientApplication, SerializableTokenCache
 
 from uuid import uuid4
-from logging import Logger
+from logging import getLogger, Logger
 from typing import Any
 from functools import wraps
 from .context import IdentityContextData
@@ -43,7 +43,7 @@ def require_context_adapter(f):
 class IdentityWebPython(object):
 
     def __init__(self, aad_config: 'AADConfig', adapter: IdentityWebContextAdapter = None, logger: Logger = None) -> None:
-        self._logger = logger or Logger('IdentityWebPython')
+        self._logger = logger or getLogger('IdentityWebPython')
         self._adapter = None
         self.aad_config = aad_config
         if adapter is not None:


### PR DESCRIPTION

## Purpose
- Use normal getLogger() helper method to obtain logger singleton instead
- Found by running Django tests using --parallel arg
- Raised exception https://github.com/python/cpython/commit/6260d9f2039976372e0896d517b3c06e606eb169#diff-1bf0ad6d121df3948853dafdd8e5406709fe0c3911b30e3cf2def41717455c98R1578


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
