### PR TITLE
bugfix: Use the intended 4XX errors in flask

### DIFF
--- a/ms_identity_web/errors.py
+++ b/ms_identity_web/errors.py
@@ -1,6 +1,15 @@
-class AuthError(Exception):
-    # basic auth exception
-    pass
+try:
+    from werkzeug.exceptions import HTTPException
+    from flask import request
+    class AuthError(HTTPException):
+        code = 401
+        status = 401
+        description = "General auth error"
+except:
+    class AuthError(Exception):
+        # basic auth exception
+        pass
+
 class AuthSecurityError(AuthError):
     # security check failed, abort auth attempt
     code = 400
@@ -21,18 +30,8 @@ class B2CPasswordError(AuthError):
     code = 300
     status = 300
     description = "password reset/redirect"
-
-try:
-    from werkzeug.exceptions import HTTPException
-    from flask import request
-    class NotAuthenticatedError(HTTPException, AuthError):
-        """Flask HTTPException Error + IdWebPy AuthError: User is not authenticated."""
-        code = 401
-        status = 401
-        description = 'User is not authenticated'
-except:
-    class NotAuthenticatedError(AuthError):
-        """IdWebPy AuthError: User is not authenticated."""
-        code = 401
-        status = 401
-        description = 'User is not authenticated'
+class NotAuthenticatedError(AuthError):
+    """IdWebPy AuthError: User is not authenticated."""
+    code = 401
+    status = 401
+    description = 'User is not authenticated'


### PR DESCRIPTION
For flask, the intended 4XX codes defined in the exceptions
were not utilized correctly. This resulted in generic 500 errors
being returned to the client on common client-side auth errors.

## Purpose
Return correct HTTP-status codes on expected client-side errors.

## Does this introduce a breaking change?
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Get a sign-in/signup page running from a flask server.
* Navigate to signup
* Time out your server session, or mess up your client-side auth state in one way or another.
* Click cancel in the sign-up form
* flask server log and HTTP-response is now a normally handled 4xx status code, instead of an internal server error.


## What to Check
Verify that the following are valid
* I decided to use 401 as a generic status code in the AuthError class. Within the current implementation, I couldn't see something more appropriate.

## Other Information
None